### PR TITLE
TW Attribution Photo Fix

### DIFF
--- a/_includes/footer.js
+++ b/_includes/footer.js
@@ -28,7 +28,7 @@ document.write(`
 
       <!-- T.Wittig Site Design Attribution -->
       <a href="https://twit96.github.io/" id="tw-attribution">
-        <img src="https://tylerwittig.com/img/icon.png" alt="TW Icon" />
+        <img src="https://tylerwittig.com/img/logo.png" alt="TW Logo" />
         Design by TW
       </a>
 


### PR DESCRIPTION
I updated the name of my image on my portfolio website, which will now cause the image in the footer of your website to give a 404. Fixed the filename in this commit!